### PR TITLE
Handle zero previous price in percentage change

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+# Ensure package root is on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot.analytics import percentage_change
+
+
+def test_percentage_change_positive():
+    assert percentage_change(100, 110) == 10.0
+
+
+def test_percentage_change_zero_previous():
+    with pytest.raises(ValueError):
+        percentage_change(0, 110)

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Trading bot utilities."""

--- a/trading_bot/analytics.py
+++ b/trading_bot/analytics.py
@@ -1,0 +1,22 @@
+"""Utility functions for trading analytics."""
+
+from __future__ import annotations
+
+
+def percentage_change(previous: float, current: float) -> float:
+    """Calculate percentage change from previous to current price.
+
+    Args:
+        previous: The previous price. Must be non-zero.
+        current: The current price.
+
+    Returns:
+        The percentage change from previous to current.
+
+    Raises:
+        ValueError: If ``previous`` is zero to avoid division by zero.
+    """
+    if previous == 0:
+        raise ValueError("previous price cannot be zero")
+
+    return (current - previous) / previous * 100.0


### PR DESCRIPTION
## Summary
- Add `percentage_change` utility for computing price movements
- Prevent division by zero by rejecting zero previous prices
- Test percentage change and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f2e2f0cc83218ce479569c7bcb77